### PR TITLE
fix not able to import with 'vue-chemistry'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
   "types": "./index.d.ts",
   "funding": "https://github.com/sponsors/antfu",
   "exports": {
+    ".": {
+      "import": "./esm/index.js",
+      "require": "./cjs/index.js"
+    },
     "./json": {
       "import": "./esm/json/index.js",
       "require": "./cjs/json/index.js"


### PR DESCRIPTION
It was not able to import with the code below.
```js
import { reactify, set } from 'vue-chemistry'
```

Importing subdirectories was ok.
```js
import { sum } from 'vue-chemistry/math'
```

Tried with vite 2.0.0-beta.21.
