### PR TITLE
feat(math): adding several math functions and math test modules

### DIFF
--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -1,4 +1,4 @@
-import { reactify } from '@vueuse/shared'
+import { MaybeRef, reactify } from '@vueuse/shared'
 
 export * from './generated'
 
@@ -24,3 +24,20 @@ export const divide = reactify((a: number, b: number) => a / b)
 
 /*@__PURE__*/
 export const subtract = reactify((a: number, b: number) => a - b)
+
+/*@__PURE__*/
+export const mod = reactify((a: number, b: number) => a % b)
+
+/*@__PURE__*/
+const gcd = (a: number, b: number): number => {
+  if (b === 0) return a
+  else return gcd(b, a % b)
+}
+
+/*@__PURE__*/
+export const rgcd = reactify(gcd)
+
+/*@__PURE__*/
+export const lcm = (a: MaybeRef<number>, b: MaybeRef<number>) => {
+  return divide(multiply(a, b), rgcd(a, b))
+}

--- a/src/math/index.ts
+++ b/src/math/index.ts
@@ -29,15 +29,15 @@ export const subtract = reactify((a: number, b: number) => a - b)
 export const mod = reactify((a: number, b: number) => a % b)
 
 /*@__PURE__*/
-const gcd = (a: number, b: number): number => {
+const pureGcd = (a: number, b: number): number => {
   if (b === 0) return a
-  else return gcd(b, a % b)
+  else return pureGcd(b, a % b)
 }
 
 /*@__PURE__*/
-export const rgcd = reactify(gcd)
+export const gcd = reactify(pureGcd)
 
 /*@__PURE__*/
 export const lcm = (a: MaybeRef<number>, b: MaybeRef<number>) => {
-  return divide(multiply(a, b), rgcd(a, b))
+  return divide(multiply(a, b), gcd(a, b))
 }

--- a/test/math.test.ts
+++ b/test/math.test.ts
@@ -1,9 +1,77 @@
 import { ref } from 'vue-demi'
-import { is, set, mod, gcd, lcm } from '../src'
+import { is, set, negative, sum, multiply, divide, subtract, mod, gcd, lcm } from '../src'
 import { $expect } from './utils'
 
 describe('reactiveMath', () => {
-  it('math', () => {
+  it('negative', () => {
+    const a = ref(9)
+    const c = negative(a)
+    $expect(is(c, -9))
+    $expect(is(a, 9))
+
+    set(a, 10)
+    $expect(is(c, -10))
+  })
+
+  it('sum', () => {
+    const a = ref(1)
+    const b = ref(2)
+    const c = ref(3)
+    const d = sum(a, b, c)
+    $expect(is(d, 6))
+
+    set(a, 10)
+    set(b, 15)
+    $expect(is(d, 28))
+  })
+
+  it('subtract', () => {
+    const a = ref(1)
+    const b = ref(2)
+    const c = subtract(a, b)
+    $expect(is(c, -1))
+
+    set(a, 20)
+    set(b, 15)
+    $expect(is(c, 5))
+  })
+
+  it('multiply', () => {
+    const a = ref(1)
+    const b = ref(2)
+    const c = ref(3)
+    const d = multiply(a, b, c)
+    $expect(is(d, 6))
+
+    set(a, 4)
+    set(b, 5)
+    $expect(is(d, 60))
+  })
+
+  it('divide', () => {
+    const a = ref(1)
+    const b = ref(2)
+    const c = divide(a, b)
+    $expect(is(c, 0.5))
+
+    set(a, 20)
+    set(b, 10)
+    $expect(is(c, 2))
+  })
+
+  it('mod', () => {
+    const a = ref(15)
+    const b = ref(9)
+    const c = mod(a, b)
+    $expect(is(c, 6))
+    $expect(is(b, 9))
+
+    set(a, 3)
+    set(b, 2)
+    $expect(is(c, 1))
+  })
+
+  it('gcd', () => {
     const a = ref(9)
     const b = ref(15)
     const c = gcd(a, b)
@@ -16,19 +84,7 @@ describe('reactiveMath', () => {
     $expect(is(a, 14))
   })
 
-  it('math', () => {
-    const a = ref(15)
-    const b = ref(9)
-    const c = mod(a, b)
-    $expect(is(c, 6))
-    $expect(is(b, 9))
-
-    set(a, 3)
-    set(b, 2)
-    $expect(is(c, 1))
-  })
-
-  it('math', () => {
+  it('lcm', () => {
     const a = ref(2)
     const b = ref(3)
     const c = lcm(a, b)

--- a/test/math.test.ts
+++ b/test/math.test.ts
@@ -1,0 +1,41 @@
+import { ref } from 'vue-demi'
+import { is, set, mod, rgcd, lcm } from '../src'
+import { $expect } from './utils'
+
+describe('reactiveMath', () => {
+  it('math', () => {
+    const a = ref(9)
+    const b = ref(15)
+    const c = rgcd(a, b)
+    $expect(is(c, 3))
+    $expect(is(a, 9))
+
+    set(a, 14)
+    set(b, 21)
+    $expect(is(c, 7))
+    $expect(is(a, 14))
+  })
+
+  it('math', () => {
+    const a = ref(15)
+    const b = ref(9)
+    const c = mod(a, b)
+    $expect(is(c, 6))
+    $expect(is(b, 9))
+
+    set(a, 3)
+    set(b, 2)
+    $expect(is(c, 1))
+  })
+
+  it('math', () => {
+    const a = ref(2)
+    const b = ref(3)
+    const c = lcm(a, b)
+    $expect(is(c, 6))
+
+    set(a, 7)
+    set(b, 14)
+    $expect(is(c, 14))
+  })
+})

--- a/test/math.test.ts
+++ b/test/math.test.ts
@@ -1,12 +1,12 @@
 import { ref } from 'vue-demi'
-import { is, set, mod, rgcd, lcm } from '../src'
+import { is, set, mod, gcd, lcm } from '../src'
 import { $expect } from './utils'
 
 describe('reactiveMath', () => {
   it('math', () => {
     const a = ref(9)
     const b = ref(15)
-    const c = rgcd(a, b)
+    const c = gcd(a, b)
     $expect(is(c, 3))
     $expect(is(a, 9))
 


### PR DESCRIPTION
Hi, 

I added three reactive math functions in the math folder, including:

+ `mod()`: get the remainder of two numbers `a` and `b` when dividing `a` by `b`.

+ `gcd()`: get the greatest common divisor of two numbers.

+ `lcm()`: get the least common multiple of two numbers.

Besides, I added math test modules, covering all functions inside `/src/math/index.ts`.
